### PR TITLE
Fix dependency version so InjectLazy works

### DIFF
--- a/code/package.json
+++ b/code/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "di": "^2.0.0-pre-14",
+    "di": "2.0.0-pre-14",
     "director": "^1.2.8",
     "react": "^0.12.2",
     "whatwg-fetch": "^0.7.0"


### PR DESCRIPTION
The caret, on the other hand, is more relaxed. It will update you to the most recent major version (the first number). In this case for me it was pre-9 and not pre-14. See http://fredkschott.com/post/2014/02/npm-no-longer-defaults-to-tildes/
